### PR TITLE
Increase memory allocated to bwa-mem2 indexing

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -59,4 +59,10 @@ process {
         errorStrategy = 'retry'
         maxRetries    = 2
     }
+
+    withName: 'BWAMEM2_INDEX' {
+        cpus = 1
+        memory = 72.GB
+        time = 2.h
+    }
 }

--- a/conf/test_hg19.config
+++ b/conf/test_hg19.config
@@ -41,3 +41,8 @@ withName: 'BWAMEM2_MEM' {
     memory = 4.GB
     time = 2.h
 }
+withName: 'BWAMEM2_INDEX' {
+    cpus = 2
+    memory = 4.GB
+    time = 2.h
+}

--- a/conf/test_hg38.config
+++ b/conf/test_hg38.config
@@ -40,3 +40,8 @@ withName: 'BWAMEM2_MEM' {
     memory = 4.GB
     time = 2.h
 }
+withName: 'BWAMEM2_INDEX' {
+    cpus = 2
+    memory = 4.GB
+    time = 2.h
+}

--- a/modules/nf-core/bwamem2/index/main.nf
+++ b/modules/nf-core/bwamem2/index/main.nf
@@ -1,6 +1,5 @@
 process BWAMEM2_INDEX {
     tag "$fasta"
-    label 'process_high'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/nf-core/bwamem2/index/main.nf
+++ b/modules/nf-core/bwamem2/index/main.nf
@@ -1,6 +1,6 @@
 process BWAMEM2_INDEX {
     tag "$fasta"
-    label 'process_single'
+    label 'process_high'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?


### PR DESCRIPTION
This is not ideal because it allocates 12 CPUs when indexing only requires one. However, it is required at this point for indexing to succeed on systems that enforce the requested memory limits.