### PR TITLE
Use latest grz-pydantic-models for end-to-end tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  MINI_TEST_VER: "0.2.0"
+  MINI_TEST_VER: "0.2.1"
   NXF_ANSI_LOG: false
 
 concurrency:

--- a/modules/local/compare_threshold/environment.yml
+++ b/modules/local/compare_threshold/environment.yml
@@ -3,4 +3,4 @@ channels:
   - bioconda
 dependencies:
   - conda-forge::pandas=2.2.3
-  - bioconda::grz-pydantic-models=2.0.2
+  - bioconda::grz-pydantic-models=2.1.0

--- a/modules/local/compare_threshold/main.nf
+++ b/modules/local/compare_threshold/main.nf
@@ -2,8 +2,8 @@ process COMPARE_THRESHOLD {
     tag "${meta.id}"
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/b1/b1d4885e454d031667ebde3af6798d5fed939309c8db196fb3289fa468d6e04f/data'
-        : 'community.wave.seqera.io/library/grz-pydantic-models_pandas:5ab296ffe88a31f9'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/2b/2b249411a56a717bd02e6029ed0c540f170fe9d197dfa6ded0b2ce3581270c39/data'
+        : 'community.wave.seqera.io/library/grz-pydantic-models_pandas:b9466bd2ba15f092'}"
 
     input:
     tuple val(meta), path(summary), path(bed), path(fastp_jsons)

--- a/modules/local/metadata_to_samplesheet/environment.yml
+++ b/modules/local/metadata_to_samplesheet/environment.yml
@@ -3,4 +3,4 @@ channels:
   - bioconda
 dependencies:
   - conda-forge::pandas=2.2.3
-  - bioconda::grz-pydantic-models=2.0.2
+  - bioconda::grz-pydantic-models=2.1.0

--- a/modules/local/metadata_to_samplesheet/main.nf
+++ b/modules/local/metadata_to_samplesheet/main.nf
@@ -3,8 +3,8 @@ process METADATA_TO_SAMPLESHEET {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/b1/b1d4885e454d031667ebde3af6798d5fed939309c8db196fb3289fa468d6e04f/data'
-        : 'community.wave.seqera.io/library/grz-pydantic-models_pandas:5ab296ffe88a31f9'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/2b/2b249411a56a717bd02e6029ed0c540f170fe9d197dfa6ded0b2ce3581270c39/data'
+        : 'community.wave.seqera.io/library/grz-pydantic-models_pandas:b9466bd2ba15f092'}"
 
     input:
     path submission_basepath

--- a/nextflow.config
+++ b/nextflow.config
@@ -208,7 +208,7 @@ manifest {
     description     = """Quality Control pipeline for 2% of data that will be submitted to the GRZ: Map and calculate coverage"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=25.04.0'
-    version         = '1.1.0'
+    version         = '1.1.1'
 }
 
 // Nextflow plugins


### PR DESCRIPTION
Schema v1.2.1 is required for the upcoming end-to-end tests. Only grz-pydantic-models v2.1.0 supports this schema and the `submissionType` of `test`.

* Also bumps grz-mini-test-data to use schema v1.2.1 and `submissionType` of `test`

I thought this might be a good time to make a small bugfix release bump, but let me know if not!