### PR TITLE
Do not fail if provided metrics are underestimated by any amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.1.2 - [17.07.2025]
+
+### Fixed
+
+- Only fail QC if pipeline computes metrics more than 5% less than reported values [#141](https://github.com/BfArM-MVH/GRZ_QC_Workflow/pull/141)
+
+## v1.1.1 - [15.07.2025]
+
+### Fixed
+
+- Improve QC reports by @twrightsman in [#137](https://github.com/BfArM-MVH/GRZ_QC_Workflow/pull/137)
+- Use latest grz-pydantic-models for end-to-end tests by @twrightsman in [#140](https://github.com/BfArM-MVH/GRZ_QC_Workflow/pull/140)
+
 ## v1.1.0 - [04.07.2025]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -116,18 +116,18 @@ For more details about the output files and reports, please refer to the [output
 | `meanDepthOfCoverageProvided`                | Mean depth of coverage from metadata/samplesheet, if provided.                               |
 | `meanDepthOfCoverageRequired`                | Mean depth of coverage required to pass QC                                                   |
 | `meanDepthOfCoverageDeviation`               | Percent deviation of computed coverage from provided coverage.                               |
-| `meanDepthOfCoverageQCStatus`                | `PASS`, `TOO LOW`, or `TOO HIGH`, depending on percent deviation.                            |
+| `meanDepthOfCoverageQCStatus`                | `PASS` or `TOO LOW`, depending on percent deviation.                                         |
 | `percentBasesAboveQualityThreshold`          | Percent of bases passing the quality threshold                                               |
 | `qualityThreshold`                           | The quality threshold to pass                                                                |
 | `percentBasesAboveQualityThresholdProvided`  | Percent of bases passing the quality threshold from metadata/samplesheet, if provided.       |
 | `percentBasesAboveQualityThresholdRequired`  | Percent of bases above the quality threshold required to pass QC                             |
 | `percentBasesAboveQualityThresholdDeviation` | Percent deviation of computed metric from provided metric.                                   |
-| `percentBasesAboveQualityThresholdQCStatus`  | `PASS`, `TOO LOW`, or `TOO HIGH`, depending on percent devation.                             |
+| `percentBasesAboveQualityThresholdQCStatus`  | `PASS` or `TOO LOW`, depending on percent devation.                                          |
 | `targetedRegionsAboveMinCoverage`            | Fraction of targeted regions above minimum coverage                                          |
 | `minCoverage`                                | Minimum coverage for target regions                                                          |
 | `targetedRegionsAboveMinCoverageProvided`    | Fraction of targeted regions above minimum coverage from metadataa/samplesheet, if provided. |
 | `targetedRegionsAboveMinCoverageRequired`    | Fraction of targeted regions above minimum coverage required to pass QC                      |
-| `targetedRegionsAboveMinCoverageQCStatus`    | `PASS`, `TOO LOW`, or `TOO HIGH`, depending on percent devation.                             |
+| `targetedRegionsAboveMinCoverageQCStatus`    | `PASS` or `TOO LOW`, depending on percent devation.                                          |
 
 ### MultiQC
 

--- a/bin/compare_threshold.py
+++ b/bin/compare_threshold.py
@@ -147,8 +147,6 @@ def main(args: argparse.Namespace):
     if pct_dev_mean_depth_of_coverage is not None:
         if pct_dev_mean_depth_of_coverage < -PCT_DEV_CUTOFF:
             qc_status_mean_depth_of_coverage = "TOO LOW"
-        elif pct_dev_mean_depth_of_coverage > PCT_DEV_CUTOFF:
-            qc_status_mean_depth_of_coverage = "TOO HIGH"
         else:
             qc_status_mean_depth_of_coverage = "PASS"
 
@@ -156,8 +154,6 @@ def main(args: argparse.Namespace):
     if pct_dev_percent_bases_above_quality_threshold is not None:
         if pct_dev_percent_bases_above_quality_threshold < -PCT_DEV_CUTOFF:
             qc_status_percent_bases_above_quality_threshold = "TOO LOW"
-        elif pct_dev_percent_bases_above_quality_threshold > PCT_DEV_CUTOFF:
-            qc_status_percent_bases_above_quality_threshold = "TOO HIGH"
         else:
             qc_status_percent_bases_above_quality_threshold = "PASS"
 
@@ -165,8 +161,6 @@ def main(args: argparse.Namespace):
     if pct_dev_targeted_regions_above_min_coverage is not None:
         if pct_dev_targeted_regions_above_min_coverage < -PCT_DEV_CUTOFF:
             qc_status_targeted_regions_above_min_coverage = "TOO LOW"
-        elif pct_dev_targeted_regions_above_min_coverage > PCT_DEV_CUTOFF:
-            qc_status_targeted_regions_above_min_coverage = "TOO HIGH"
         else:
             qc_status_targeted_regions_above_min_coverage = "PASS"
 
@@ -178,9 +172,9 @@ def main(args: argparse.Namespace):
         )
     ):
         quality_check_passed = (
-            (abs(pct_dev_mean_depth_of_coverage) <= PCT_DEV_CUTOFF)
-            and (abs(pct_dev_percent_bases_above_quality_threshold) <= PCT_DEV_CUTOFF)
-            and (abs(pct_dev_targeted_regions_above_min_coverage) <= PCT_DEV_CUTOFF)
+            (pct_dev_mean_depth_of_coverage >= -PCT_DEV_CUTOFF)
+            and (pct_dev_percent_bases_above_quality_threshold >= -PCT_DEV_CUTOFF)
+            and (pct_dev_targeted_regions_above_min_coverage >= -PCT_DEV_CUTOFF)
         )
         quality_control_status = "PASS" if quality_check_passed else "FAIL"
     else:

--- a/bin/merge_reports.py
+++ b/bin/merge_reports.py
@@ -62,7 +62,6 @@ def main(args: argparse.Namespace):
         #         - s_eq: "PASS"
         #       fail:
         #         - s_eq: "TOO LOW"
-        #         - s_eq: "TOO HIGH"
         #   percentBasesAboveQualityThreshold:
         #     title: "Percent Bases Above Quality Threshold"
         #     description: "Percentage of unfiltered read bases that are above the minimum quality score."
@@ -90,7 +89,6 @@ def main(args: argparse.Namespace):
         #         - s_eq: "PASS"
         #       fail:
         #         - s_eq: "TOO LOW"
-        #         - s_eq: "TOO HIGH"
         #   targetedRegionsAboveMinCoverage:
         #     title: "Targeted Regions Above Minimum Coverage"
         #     description: "Proportion of target regions above the minimum coverage threshold."
@@ -115,7 +113,6 @@ def main(args: argparse.Namespace):
         #         - s_eq: "PASS"
         #       fail:
         #         - s_eq: "TOO LOW"
-        #         - s_eq: "TOO HIGH"
         """)
         )
         df_merged.to_csv(mqc_out, index=False)

--- a/nextflow.config
+++ b/nextflow.config
@@ -208,7 +208,7 @@ manifest {
     description     = """Quality Control pipeline for 2% of data that will be submitted to the GRZ: Map and calculate coverage"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=25.04.0'
-    version         = '1.1.1'
+    version         = '1.1.2'
 }
 
 // Nextflow plugins


### PR DESCRIPTION
Resolves https://github.com/BfArM-MVH/GRZ_QC_Workflow/issues/138

It was determined in the technical meeting between BfArM and LEs yesterday that underestimating metrics in `metadata.json`/samplesheet by any amount is not a QC fail.

QC only fails if the pipeline calculates metrics that are _less than_ the reported values in `metadata.json`/samplesheet by more than 5%.