### PR TITLE
Ignore non-QCed library types in samplesheet generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Ignore non-QCed library types in submission metadata (e.g. RNA) [#149](https://github.com/BfArM-MVH/GRZ_QC_Workflow/pull/149)
+
 ## v1.1.5 - [01.08.2025]
 
 ### Added

--- a/bin/metadata_to_samplesheet.py
+++ b/bin/metadata_to_samplesheet.py
@@ -14,6 +14,8 @@ from grz_pydantic_models.submission.metadata import (
     SequencingLayout,
 )
 
+QCED_LIBRARY_TYPES = {"panel", "wgs", "wes", "panel_lr", "wgs_lr", "wes_lr"}
+
 
 def sanitize(s: str) -> str:
     return s.replace(" ", "_")
@@ -36,7 +38,9 @@ def main(submission_root: Path):
         for lab_datum_index, lab_datum in enumerate(donor.lab_data):
             sample_id = f"{donor.relation}{donor_index}_{lab_datum.sequence_subtype}{lab_datum_index}"
 
-            if lab_datum.sequence_data is not None:
+            if (lab_datum.sequence_data is not None) and (
+                lab_datum.library_type in QCED_LIBRARY_TYPES
+            ):
                 read_files = []
 
                 for file in lab_datum.sequence_data.files:


### PR DESCRIPTION
Resolves https://github.com/BfArM-MVH/GRZ_QC_Workflow/issues/148

## Tasks

- [x] Request reviews from the relevant people
- [x] Update [CHANGELOG.md](https://github.com/BfArM-MVH/GRZ_QC_Workflow/blob/main/CHANGELOG.md)
- [ ] Increase `manifest.version` in `nextflow.config` _only if_ tagging a new release
  - Consider [SemVer](https://semver.org). In short, increase
    - major version for breaking changes
    - minor version for new features
    - patch version for bug fixes
