### PR TITLE
Use vendor-recommended read filter for Nanopore

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -17,13 +17,16 @@ process {
             path:"${params.outdir}",
             mode: params.publish_dir_mode]
     }
+    withName: FASTPLONG {
+        ext.args = {meta.is_pacbio ? "" : "--mean_qual 10"}
+    }
     withName: BWAMEM2_MEM {
         ext.args   = { "-R \'${meta.read_group}\'" }
     }
     withName: MINIMAP2_ALIGN {
         ext.args   = {[
             "-R \'${meta.read_group}\'",
-            "-x ${meta.mm2_preset}"
+            "-x " + (meta.is_pacbio ? "map-hifi" : "map-ont")
         ].join(' ').trim()}
         publishDir = [
             path: {"${params.outdir}/${meta.id}/alignments_long_read/"},

--- a/subworkflows/local/align_merge_long/main.nf
+++ b/subworkflows/local/align_merge_long/main.nf
@@ -45,7 +45,7 @@ workflow ALIGN_MERGE_LONG {
             newMeta.remove('read_group')
             newMeta.remove('flowcellId')
             newMeta.remove('runId')
-            newMeta.remove('mm2_preset')
+            newMeta.remove('is_pacbio')
             [newMeta + [id: newMeta.sample], bam]
         }
         .groupTuple()


### PR DESCRIPTION
**PLEASE NOTE:** This has _NOT_ yet been approved by BfArM, and may not be. Do not rely on this to be merged.

The `fastplong` defaults may be too strict for Nanopore at the moment. Let's keep this PR open while we test this on real data. This uses the current reference Nanopore cutoff of Q10 average read base quality: https://github.com/epi2me-labs/wf-basecalling

## Tasks

- [ ] Request reviews from the relevant people
- [ ] Update [CHANGELOG.md](https://github.com/BfArM-MVH/GRZ_QC_Workflow/blob/main/CHANGELOG.md)
- [ ] Increase `manifest.version` in `nextflow.config` _only if_ tagging a new release
  - Consider [SemVer](https://semver.org). In short, increase
    - major version for breaking changes
    - minor version for new features
    - patch version for bug fixes
