### PR TITLE
Sort paired-end FASTQ files before alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Ignore non-QCed library types in submission metadata (e.g. RNA) [#149](https://github.com/BfArM-MVH/GRZ_QC_Workflow/pull/149)
-- The `calculate_basequality` module is deprecated as it was not performant for big files. fastp JSON input is not mandatory for aligned file input.
+- The `calculate_basequality` module is deprecated as it was not performant for big files. fastp JSON input is now mandatory for aligned file input.
+- Sort paired-end FASTQ files before alignment [#152](https://github.com/BfArM-MVH/GRZ_QC_Workflow/pull/152)
 
 ## v1.1.5 - [01.08.2025]
 

--- a/modules/local/fastq_sort/environment.yml
+++ b/modules/local/fastq_sort/environment.yml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::parallel=20250822
+  - bioconda::fastq-tools=0.8.3
+  - bioconda::samtools=1.22.1

--- a/modules/local/fastq_sort/main.nf
+++ b/modules/local/fastq_sort/main.nf
@@ -17,8 +17,7 @@ process FASTQ_SORT {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def cpus_per_subtask = task.cpus
-    // reads.size()
+    def cpus_per_subtask = max(task.cpus.intdiv(reads.size()), 1)
 
     if (meta.single_end) {
         // single-end FASTQs don't require sorting
@@ -35,7 +34,7 @@ process FASTQ_SORT {
     }
     else {
         """
-        parallel 'fastq-sort ${args} {} | bgzip --stdout --threads ${cpus_per_subtask} > ${prefix}.R{#}.sorted.fastq.gz' ::: ${reads.join(' ')}
+        parallel 'bgzip --stdout --decompress --threads ${cpus_per_subtask} {} | fastq-sort ${args} | bgzip --stdout --threads ${cpus_per_subtask} > ${prefix}.R{#}.sorted.fastq.gz' ::: ${reads.join(' ')}
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":

--- a/modules/local/fastq_sort/main.nf
+++ b/modules/local/fastq_sort/main.nf
@@ -1,0 +1,48 @@
+process FASTQ_SORT {
+    tag "${meta.id}"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6b/6b85d6776227c966f456dc4b1d1edf6db645bef4cfce2bdc928151f64fca5316/data'
+        : 'community.wave.seqera.io/library/fastq-tools_samtools_parallel:2a78b0b4ab3491b2'}"
+
+    input:
+    tuple val(meta), path(reads)
+
+    output:
+    tuple val(meta), path('*.sorted.fastq.gz'), emit: reads
+    path "versions.yml", emit: versions
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def cpus_per_subtask = task.cpus
+    // reads.size()
+
+    if (meta.single_end) {
+        // single-end FASTQs don't require sorting
+        """
+        ln -s ${reads} ${prefix}.sorted.fastq.gz
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            parallel: \$(parallel --version | head -n1 | sed 's/^GNU parallel //')
+            fastq-sort: \$(fastq-sort --version | cut -f3 -d' ')
+            samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+        END_VERSIONS
+        """
+    }
+    else {
+        """
+        parallel 'fastq-sort ${args} {} | bgzip --stdout --threads ${cpus_per_subtask} > ${prefix}.R{#}.sorted.fastq.gz' ::: ${reads.join(' ')}
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            parallel: \$(parallel --version | head -n1 | sed 's/^GNU parallel //')
+            fastq-sort: \$(fastq-sort --version | cut -f3 -d' ')
+            samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+        END_VERSIONS
+        """
+    }
+}

--- a/subworkflows/local/fastq_align_bwa_markduplicates/main.nf
+++ b/subworkflows/local/fastq_align_bwa_markduplicates/main.nf
@@ -4,6 +4,7 @@
 
 include { BWAMEM2_MEM              } from '../../../modules/nf-core/bwamem2/mem/main'
 include { BAM_INDEX_STATS_SAMTOOLS } from '../../local/bam_index_stats_samtools/main'
+include { FASTQ_SORT               } from '../../../modules/local/fastq_sort/main'
 include { SAMTOOLS_MERGE           } from '../../../modules/nf-core/samtools/merge/main'
 include { SAMBAMBA_MARKDUP         } from '../../../modules/nf-core/sambamba/markdup/main'
 
@@ -19,9 +20,16 @@ workflow FASTQ_ALIGN_BWA_MARKDUPLICATES {
     main:
     ch_versions = Channel.empty()
 
+    // Sort paired-end FASTQ files (required for bwa-mem)
+    FASTQ_SORT(
+        ch_reads
+    )
+
+    ch_versions = ch_versions.mix(FASTQ_SORT.out.versions)
+
     // Map reads with BWA - per lane
     BWAMEM2_MEM(
-        ch_reads,
+        FASTQ_SORT.out.reads,
         ch_index,
         ch_fasta,
         val_sort_bam,


### PR DESCRIPTION
I got some paired-end FASTQ files from LEs that were not sorted, causing bwa-mem2 to crash.

## Tasks

- [x] Request reviews from the relevant people
- [x] Update [CHANGELOG.md](https://github.com/BfArM-MVH/GRZ_QC_Workflow/blob/main/CHANGELOG.md)
