### PR TITLE
Gate FASTQ sorting behind CLI parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## v1.2.0 - [09.10.2025]
 
 - Ignore non-QCed library types in submission metadata (e.g. RNA) [#149](https://github.com/BfArM-MVH/GRZ_QC_Workflow/pull/149)
 - The `calculate_basequality` module is deprecated as it was not performant for big files. fastp JSON input is not mandatory for aligned file input.
 - Bump grz-pydantic-models to support metadata v1.3 [#153](https://github.com/BfArM-MVH/GRZ_QC_Workflow/pull/153)
-- Sort paired-end FASTQ files before alignment [#152](https://github.com/BfArM-MVH/GRZ_QC_Workflow/pull/152)
+- Add parameter to enable sorting paired-end FASTQ files before alignment [#152](https://github.com/BfArM-MVH/GRZ_QC_Workflow/pull/152)
 
 ## v1.1.5 - [01.08.2025]
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -132,15 +132,15 @@ Since raw input files are missing, the user must provide a fastp JSON report. As
 
 ```json
 {
-	"summary": {
-		"before_filtering": {
-			"total_reads":1094,
-			"total_bases":110494,
-			"q20_bases":94654,
-			"q30_bases":83570,
-			"q20_rate":0.856644,
-			"q30_rate":0.756331
-		},
+  "summary": {
+    "before_filtering": {
+      "total_reads": 1094,
+      "total_bases": 110494,
+      "q20_bases": 94654,
+      "q30_bases": 83570,
+      "q20_rate": 0.856644,
+      "q30_rate": 0.756331
+    }
   }
 }
 ```

--- a/modules/local/fastq_sort/main.nf
+++ b/modules/local/fastq_sort/main.nf
@@ -17,7 +17,7 @@ process FASTQ_SORT {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def cpus_per_subtask = max(task.cpus.intdiv(reads.size()), 1)
+    def cpus_per_subtask = Math.max(task.cpus.intdiv(reads.size()), 1)
 
     if (meta.single_end) {
         // single-end FASTQs don't require sorting

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,6 +19,7 @@ params {
     target                     = null
     reference_path             = null
     skip_markdup               = false
+    sort_paired_fastq          = false
 
     // MultiQC options
     multiqc_config             = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -210,7 +210,7 @@ manifest {
     description     = """Quality Control pipeline for 2% of data that will be submitted to the GRZ: Map and calculate coverage"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=25.04.0'
-    version         = '1.1.5'
+    version         = '1.2.0'
 }
 
 // Nextflow plugins

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -54,6 +54,12 @@
                     "default": false,
                     "fa_icon": "fas fa-check-square"
                 },
+                "sort_paired_fastq": {
+                    "type": "boolean",
+                    "description": "Whether to sort paired-end FASTQ files before alignment.",
+                    "default": false,
+                    "fa_icon": "fas fa-check-square"
+                },
                 "outdir": {
                     "type": "string",
                     "format": "directory-path",

--- a/subworkflows/local/align_merge_long/main.nf
+++ b/subworkflows/local/align_merge_long/main.nf
@@ -66,9 +66,11 @@ workflow ALIGN_MERGE_LONG {
         [newMeta + [id: newMeta.sample], bam]
     }
 
-    ch_alignments_newMeta.map { meta, _bam ->
-        tuple(meta, meta.fastp_json)
-    }.set{jsonstats}
+    ch_alignments_newMeta
+        .map { meta, _bam ->
+            tuple(meta, meta.fastp_json)
+        }
+        .set { jsonstats }
 
     // Merge aligned bams with the alignments coming from samplesheet
 

--- a/subworkflows/local/fastq_align_bwa_markduplicates/main.nf
+++ b/subworkflows/local/fastq_align_bwa_markduplicates/main.nf
@@ -72,9 +72,11 @@ workflow FASTQ_ALIGN_BWA_MARKDUPLICATES {
         [newMeta + [id: newMeta.sample], bam]
     }
 
-    ch_alignments_newMeta.map { meta, _bam ->
-        tuple(meta, meta.fastp_json)
-    }.set{jsonstats}
+    ch_alignments_newMeta
+        .map { meta, _bam ->
+            tuple(meta, meta.fastp_json)
+        }
+        .set { jsonstats }
 
     // Sort, index BAM file and run samtools stats, flagstat and idxstats
     BAM_INDEX_STATS_SAMTOOLS(

--- a/subworkflows/local/fastq_align_bwa_markduplicates/main.nf
+++ b/subworkflows/local/fastq_align_bwa_markduplicates/main.nf
@@ -20,16 +20,22 @@ workflow FASTQ_ALIGN_BWA_MARKDUPLICATES {
     main:
     ch_versions = Channel.empty()
 
-    // Sort paired-end FASTQ files (required for bwa-mem)
-    FASTQ_SORT(
-        ch_reads
-    )
+    ch_alignment_reads = ch_reads
 
-    ch_versions = ch_versions.mix(FASTQ_SORT.out.versions)
+    if (params.sort_paired_fastq) {
+        // Sort paired-end FASTQ files (required for bwa-mem)
+        FASTQ_SORT(
+            ch_reads
+        )
+
+        ch_versions = ch_versions.mix(FASTQ_SORT.out.versions)
+
+        ch_alignment_reads = FASTQ_SORT.out.reads
+    }
 
     // Map reads with BWA - per lane
     BWAMEM2_MEM(
-        FASTQ_SORT.out.reads,
+        ch_alignment_reads,
         ch_index,
         ch_fasta,
         val_sort_bam,
@@ -80,14 +86,15 @@ workflow FASTQ_ALIGN_BWA_MARKDUPLICATES {
     ch_bam = BAM_INDEX_STATS_SAMTOOLS.out.bam
     ch_bai = BAM_INDEX_STATS_SAMTOOLS.out.bai
 
-    if (!params.skip_markdup){
+    if (!params.skip_markdup) {
         // Mark duplicates with sambamba
         SAMBAMBA_MARKDUP(
             BAM_INDEX_STATS_SAMTOOLS.out.bam
         )
         ch_versions = ch_versions.mix(SAMBAMBA_MARKDUP.out.versions)
-        ch_bam  = SAMBAMBA_MARKDUP.out.bam // channel: [ val(meta), path(bam) ]
-        ch_bai  = SAMBAMBA_MARKDUP.out.bai // channel: [ val(meta), path(bai) ]
+        ch_bam = SAMBAMBA_MARKDUP.out.bam
+        // channel: [ val(meta), path(bam) ]
+        ch_bai = SAMBAMBA_MARKDUP.out.bai
     }
 
     emit:


### PR DESCRIPTION
Plain `max()` seems to return a function instead of calculating immediately so it was being converted to strings like `nextflow.extension.OpCall@741ad976` instead of an integer.

## Tasks

- [x] Request reviews from the relevant people
- [x] Update [CHANGELOG.md](https://github.com/BfArM-MVH/GRZ_QC_Workflow/blob/main/CHANGELOG.md)
  - not necessary for this PR since it's a fix to an unreleased feature