### PR TITLE
Generalize BED file parsing: skip header, null checks and updated column counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Fixed BED parsing to skip headers/comments and added strict validation for critical columns [#188](https://github.com/BfArM-MVH/GRZ_QC_Workflow/pull/188)
+
 ## v1.3.1
 
 - Fix QC errors on non-index patients [#185](https://github.com/BfArM-MVH/GRZ_QC_Workflow/pull/185)

--- a/bin/convert_bed_chrom.py
+++ b/bin/convert_bed_chrom.py
@@ -23,7 +23,9 @@ def read_bed_file(
     with open_func(file_path, "rb") as f:
         for line in f:
             line_decoded = line.strip().decode("utf-8")
-            if not line_decoded or any(line_decoded.startswith(x) for x in ["#", "track", "browser"]):
+            if not line_decoded or any(
+                line_decoded.startswith(x) for x in ["#", "track", "browser"]
+            ):
                 data_start_line += 1
                 continue
             num_columns = len(line_decoded.split("\t"))
@@ -31,12 +33,14 @@ def read_bed_file(
 
     # Enforce a minimum of three columns
     if num_columns < 3:
-        raise ValueError(f"Invalid BED: {file_path} has {num_columns} columns. Expected >= 3.")
+        raise ValueError(
+            f"Invalid BED: {file_path} has {num_columns} columns. Expected >= 3."
+        )
 
     if column_names is None:
         # Default column names for the first 6 standard BED fields
         default_names = ["chrom", "start", "end", "name", "score", "strand"]
-        
+
         if num_columns <= len(default_names):
             column_names = default_names[:num_columns]
         else:
@@ -47,10 +51,14 @@ def read_bed_file(
     # Create dtype_dict dynamically based on columns that exist
     # Use 'Int64' for start/end to allow the strict null check later on
     base_types = {
-        "chrom": "str", "start": "Int64", "end": "Int64",
-        "name": "str", "score": "float64", "strand": "str"
+        "chrom": "str",
+        "start": "Int64",
+        "end": "Int64",
+        "name": "str",
+        "score": "float64",
+        "strand": "str",
     }
-    
+
     # Only include types for columns actually present in column_names
     dtype_dict = {col: base_types.get(col, "str") for col in column_names}
     dtype_dict.update(dtypes or {})
@@ -71,7 +79,9 @@ def read_bed_file(
     for col in ["chrom", "start", "end"]:
         if bed_df[col].isnull().any():
             row_idx = bed_df[bed_df[col].isnull()].index[0] + data_start_line + 1
-            raise ValueError(f"ERROR: Null value detected in '{col}' at line {row_idx} of {file_path.name}.")
+            raise ValueError(
+                f"ERROR: Null value detected in '{col}' at line {row_idx} of {file_path.name}."
+            )
 
     # Cast to standard int for output
     bed_df["start"] = bed_df["start"].astype(int)

--- a/bin/convert_bed_chrom.py
+++ b/bin/convert_bed_chrom.py
@@ -14,74 +14,68 @@ def read_bed_file(
 ):
     file_path = Path(file_path)
     is_gzipped = file_path.name.endswith(".gz")
+    # Determine if the file is compressed
+    open_func = gzip.open if is_gzipped else open
+
+    # Load the file, identify where data starts and infer the number of columns
+    data_start_line = 0
+    num_columns = 0
+    with open_func(file_path, "rb") as f:
+        for line in f:
+            line_decoded = line.strip().decode("utf-8")
+            if not line_decoded or any(line_decoded.startswith(x) for x in ["#", "track", "browser"]):
+                data_start_line += 1
+                continue
+            num_columns = len(line_decoded.split("\t"))
+            break
+
+    # Enforce a minimum of three columns
+    if num_columns < 3:
+        raise ValueError(f"Invalid BED: {file_path} has {num_columns} columns. Expected >= 3.")
 
     if column_names is None:
-        # Determine if the file is compressed
-        open_func = gzip.open if is_gzipped else open
-
-        # Load the file and infer the number of columns from the first line
-        with open_func(file_path, "rb") as f:
-            first_line = f.readline().strip().decode("utf-8").split("\t")
-            num_columns = len(first_line)
-
-        # Default column names for the first 12 standard BED fields
-        default_column_names = [
-            "chrom",
-            "start",
-            "end",
-            "name",
-            "score",
-            "strand",
-            "thickStart",
-            "thickEnd",
-            "itemRgb",
-            "blockCount",
-            "blockSizes",
-            "blockStarts",
-        ]
-
-        # If there are more columns than default names, add generic names
-        if num_columns > len(default_column_names):
-            extra_columns = [
-                f"extra_col_{i}" for i in range(num_columns - len(default_column_names))
-            ]
-            column_names = default_column_names + extra_columns
+        # Default column names for the first 6 standard BED fields
+        default_names = ["chrom", "start", "end", "name", "score", "strand"]
+        
+        if num_columns <= len(default_names):
+            column_names = default_names[:num_columns]
         else:
-            column_names = default_column_names[:num_columns]
+            # Add generic names for columns beyond the standard 6
+            extra = [f"extra_col_{i}" for i in range(num_columns - len(default_names))]
+            column_names = default_names + extra
 
-    # Define data types (dtypes) for the columns
-    dtype_dict = {
-        "chrom": "str",  # Chromosome names are typically strings
-        "start": "int64",  # Start position is integer
-        "end": "int64",  # End position is integer
-        "name": "str",  # Name is typically a string
-        "score": "float64",  # Score is usually a float (can also be integer)
-        "strand": "str",  # Strand is a string (either '+' or '-')
-        "thickStart": "int64",  # thickStart is an integer
-        "thickEnd": "int64",  # thickEnd is an integer
-        "itemRgb": "str",  # itemRgb is a string (RGB value)
-        "blockCount": "int64",  # blockCount is an integer
-        "blockSizes": "str",  # blockSizes is a string (comma-separated list)
-        "blockStarts": "str",  # blockStarts is a string (comma-separated list)
+    # Create dtype_dict dynamically based on columns that exist
+    # Use 'Int64' for start/end to allow the strict null check later on
+    base_types = {
+        "chrom": "str", "start": "Int64", "end": "Int64",
+        "name": "str", "score": "float64", "strand": "str"
     }
-
-    # Apply dtypes to extra columns if present
-    dtype_dict.update(
-        {col: "str" for col in column_names[12:]}
-    )  # Default extra columns to string
-
-    # Update with user-specified dtypes (overwrites defaults)
+    
+    # Only include types for columns actually present in column_names
+    dtype_dict = {col: base_types.get(col, "str") for col in column_names}
     dtype_dict.update(dtypes or {})
 
-    # Read the BED file with inferred column names and dtypes
     bed_df = pd.read_csv(
         file_path,
         sep="\t",
         names=column_names,
+        header=None,
+        skiprows=data_start_line,
         dtype=dtype_dict,
         comment="#",
+        na_values=["."],
         compression="gzip" if is_gzipped else None,
     )
+
+    # Null Check: Fail if '.' present in chrom, start, or end
+    for col in ["chrom", "start", "end"]:
+        if bed_df[col].isnull().any():
+            row_idx = bed_df[bed_df[col].isnull()].index[0] + data_start_line + 1
+            raise ValueError(f"ERROR: Null value detected in '{col}' at line {row_idx} of {file_path.name}.")
+
+    # Cast to standard int for output
+    bed_df["start"] = bed_df["start"].astype(int)
+    bed_df["end"] = bed_df["end"].astype(int)
 
     return bed_df
 

--- a/tests/data/test-datasets_tiny/files/donor_001/target.bed
+++ b/tests/data/test-datasets_tiny/files/donor_001/target.bed
@@ -1,2 +1,5 @@
-22	13270	13400	gene1
-22	13600	13973	gene2
+track name="TestRegions" description="Regions for testing"
+# This is a comment that should be skipped
+browser position 22:10000-20000
+22	13270	13400	gene1	.	+
+22	13600	13973	gene2	0.9	-


### PR DESCRIPTION
Problem description: The current BED reader is too rigid and crashes in these situations:
- It crashes if the file starts with "track" or "browser" lines (common in UCSC or Ion Torrent files)
- It crashes or fails if there are dots (".") or empty spaces in the chromosome or coordinate columns.
- It expects a fixed number of columns, which causes errors if the file has only 3 or 4 columns.
e.g.
track name="MyData"
chr1  100  200  .  .  +

Proposed changes:
- Header Detection: The script tries to find where the real data starts and skips any header lines via skiprows.
- The function counts how many columns are actually in the file and names them correctly.
- The script treats dots (.) as empty values.
- Added a strict null check for chrom, start, and end.
- Utilizes Pandas' Int64 type during ingestion to allow for safe validation before casting to standard integers.

## Tasks

- [ ] Request reviews from the relevant people
- [ ] Update [CHANGELOG.md](https://github.com/BfArM-MVH/GRZ_QC_Workflow/blob/main/CHANGELOG.md)
- [ ] Increase `manifest.version` in `nextflow.config` _only if_ tagging a new release
  - Consider [SemVer](https://semver.org). In short, increase
    - major version for breaking changes
    - minor version for new features
    - patch version for bug fixes
