### PR TITLE
chore: exclude CHANGELOG.md from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 email_template.html
 adaptivecard.json
 slackreport.json
+CHANGELOG.md
 .nextflow*
 work/
 data/


### PR DESCRIPTION
release-please writes CHANGELOG.md in its own format and re-writes it on every release PR. Prettier formatting fights with that. Excluding it from `prettier --check .` avoids spurious linting failures on release PRs.