### PR TITLE
feat!: switch report.csv to deduplicated output

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -80,6 +80,7 @@ process {
     }
     withName: MERGE_REPORTS_DEDUPLICATED {
         ext.prefix = "nonredundant_"
+        ext.create_alias = "report.csv"
         publishDir = [
             path:"${params.outdir}/",
             pattern: "*report.{csv,xlsx}",
@@ -88,7 +89,6 @@ process {
     }
     withName: MERGE_REPORTS_UNDEDUPLICATED {
         ext.prefix = "redundant_"
-        ext.create_alias = "report.csv"
         publishDir = [
             path:"${params.outdir}/",
             pattern: "*report.{csv,xlsx}",


### PR DESCRIPTION
## Summary

Switch `report.csv` alias from `redundant_report.csv` to `nonredundant_report.csv` so consumers reading `report.csv` get deduplicated results by default.

BREAKING CHANGE: `report.csv` now points to the deduplicated (nonredundant) merge output instead of the redundant one. Downstream tooling expecting duplicate rows in `report.csv` must read `redundant_report.csv` directly.

## Tasks

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat!` for breaking change)
- [ ] Request reviews from the relevant people
