### PR TITLE
fix(deps): bump grz-pydantic-models to 2.7.1

### DIFF
--- a/bin/metadata_to_samplesheet.py
+++ b/bin/metadata_to_samplesheet.py
@@ -138,7 +138,6 @@ def main(submission_root: Path):
                                     30
                                     if thresholds is None
                                     else int(
-                                        # int cast to workaround wrong float type in grz-pydantic-models v2.4.0
                                         thresholds.percent_bases_above_quality_threshold.quality_threshold
                                     )
                                 ),

--- a/modules/local/compare_threshold/environment.yml
+++ b/modules/local/compare_threshold/environment.yml
@@ -3,4 +3,4 @@ channels:
   - bioconda
 dependencies:
   - conda-forge::pandas=2.3.3
-  - bioconda::grz-pydantic-models=2.5.0
+  - bioconda::grz-pydantic-models=2.7.1

--- a/modules/local/compare_threshold/main.nf
+++ b/modules/local/compare_threshold/main.nf
@@ -2,8 +2,8 @@ process COMPARE_THRESHOLD {
     tag "${meta.id}"
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/13/135379b52c2d54842b471b5820082807fa0aae33cf1df118ebb3813dfe062c97/data'
-        : 'community.wave.seqera.io/library/grz-pydantic-models_pandas:9c55bee92ebacc5d'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/97/97e40ef01757e3804562c0e7de9ada44dd8c4b6cdcee3e4d5d554aca68b22545/data'
+        : 'community.wave.seqera.io/library/pandas_grz-pydantic-models:1e97fd2149afc157'}"
 
     input:
     tuple val(meta), path(summary), path(bed), path(fastp_jsons)

--- a/modules/local/metadata_to_samplesheet/environment.yml
+++ b/modules/local/metadata_to_samplesheet/environment.yml
@@ -3,4 +3,4 @@ channels:
   - bioconda
 dependencies:
   - conda-forge::pandas=2.3.3
-  - bioconda::grz-pydantic-models=2.5.0
+  - bioconda::grz-pydantic-models=2.7.1

--- a/modules/local/metadata_to_samplesheet/main.nf
+++ b/modules/local/metadata_to_samplesheet/main.nf
@@ -3,8 +3,8 @@ process METADATA_TO_SAMPLESHEET {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/13/135379b52c2d54842b471b5820082807fa0aae33cf1df118ebb3813dfe062c97/data'
-        : 'community.wave.seqera.io/library/grz-pydantic-models_pandas:9c55bee92ebacc5d'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/97/97e40ef01757e3804562c0e7de9ada44dd8c4b6cdcee3e4d5d554aca68b22545/data'
+        : 'community.wave.seqera.io/library/pandas_grz-pydantic-models:1e97fd2149afc157'}"
 
     input:
     path submission_basepath

--- a/tests/data/grz-example-submissions/metadata/metadata.v1.1.1-r2.json
+++ b/tests/data/grz-example-submissions/metadata/metadata.v1.1.1-r2.json
@@ -88,50 +88,6 @@
                         ],
                         "files": [
                             {
-                                "filePath": "donor_001/NIST7035_1_R1.fastq.gz",
-                                "fileType": "fastq",
-                                "checksumType": "sha256",
-                                "fileChecksum": "db53fb6c3bf25292880245e5375d636cc711a4e2c7226302cb599e341f9ce5a7",
-                                "fileSizeInBytes": 3343564,
-                                "readOrder": "R1",
-                                "readLength": 101,
-                                "flowcellId": "NIST7035",
-                                "laneId": "1"
-                            },
-                            {
-                                "filePath": "donor_001/NIST7035_1_R2.fastq.gz",
-                                "fileType": "fastq",
-                                "checksumType": "sha256",
-                                "fileChecksum": "e40aa2eadbbdbae958258a79d1f6c005a539f878466539f1e6d98a38faddca14",
-                                "fileSizeInBytes": 3454821,
-                                "readOrder": "R2",
-                                "readLength": 101,
-                                "flowcellId": "NIST7035",
-                                "laneId": "1"
-                            },
-                            {
-                                "filePath": "donor_001/NIST7035_2_R1.fastq.gz",
-                                "fileType": "fastq",
-                                "checksumType": "sha256",
-                                "fileChecksum": "21eb0497dbae3e74268d64ac543c2ad145d66bf044da5d0b0b021ffed978a792",
-                                "fileSizeInBytes": 3414245,
-                                "readOrder": "R1",
-                                "readLength": 101,
-                                "flowcellId": "NIST7035",
-                                "laneId": "2"
-                            },
-                            {
-                                "filePath": "donor_001/NIST7035_2_R2.fastq.gz",
-                                "fileType": "fastq",
-                                "checksumType": "sha256",
-                                "fileChecksum": "be172173202fe25b0e2f9ed049f3e945b089255a108e09e519453c6757a0b860",
-                                "fileSizeInBytes": 3518760,
-                                "readOrder": "R2",
-                                "readLength": 101,
-                                "flowcellId": "NIST7035",
-                                "laneId": "2"
-                            },
-                            {
                                 "filePath": "donor_001/NIST7086_1_R1.fastq.gz",
                                 "fileType": "fastq",
                                 "checksumType": "sha256",
@@ -193,7 +149,7 @@
                     }
                 },
                 {
-                    "labDataName": "Tumor DNA sample less samples",
+                    "labDataName": "Tumor DNA sample alt flowcell",
                     "tissueOntology": {
                         "name": "UBERON",
                         "version": "1.5"


### PR DESCRIPTION
## Summary

Bumps `grz-pydantic-models` 2.5.0 → 2.7.1 in both `metadata_to_samplesheet`
and `compare_threshold` modules.

Pulls in upstream bug fixes (consent period datetime, `minReadLength`
default, timezone handling in `consent_by_code`) and the 2026-06-01
metadata spec adjustments. Existing valid submissions continue to load
unchanged. Seqera Wave container hashes (docker image + singularity blob)
are refreshed for the updated conda environment.

The local `test_full` fixture happened to reuse the same fastq files
across two `labData` entries on the same donor, which the duplicate
checksum check added in 2.6.0 flags as invalid. The two entries are
split onto disjoint flowcells (NIST7086 vs NIST7035) and the second is
renamed to reflect its new content.

Drops the stale v2.4.0 workaround comment in `metadata_to_samplesheet.py`;
the `int` cast itself is still required because `quality_threshold`
remains typed as `float` upstream.

## Tasks

- [x] PR title follows Conventional Commits
- [ ] Request reviews from the relevant people
