### PR TITLE
fix(multiqc): split GRZ QC dedup/redundant report sections

### DIFF
--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -5,6 +5,7 @@ report_comment: >
 
 module_order:
   - grz_qc:
+  - grz_qc_redundant:
   - fastqc:
       name: "FastQC"
   - fastp:

--- a/bin/merge_reports.py
+++ b/bin/merge_reports.py
@@ -17,9 +17,9 @@ def main(args: argparse.Namespace):
     # write out annotated report for MultiQC
     with open(f"{args.output_prefix}_mqc.csv", "w") as mqc_out:
         mqc_out.write(
-            dedent("""\
-        # id: "grz_qc"
-        # section_name: "GRZ QC Results"
+            dedent(f"""\
+        # id: "{args.mqc_id}"
+        # section_name: "{args.mqc_section_name}"
         # description: "Results from the GRZ internal QC pipeline."
         # format: "csv"
         # plot_type: "table"
@@ -135,6 +135,16 @@ if __name__ == "__main__":
         "--workflow_version",
         required=True,
         help="GRZ QC workflow version to record in the report",
+    )
+    parser.add_argument(
+        "--mqc_id",
+        default="grz_qc",
+        help="MultiQC custom-content section id (must be unique per table to avoid collisions)",
+    )
+    parser.add_argument(
+        "--mqc_section_name",
+        default="GRZ QC Results",
+        help="MultiQC custom-content section display name",
     )
     args = parser.parse_args()
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -82,6 +82,8 @@ process {
         ext.prefix = "nonredundant_"
         ext.version_suffix = "nonredundant"
         ext.create_alias = "report.csv"
+        ext.mqc_id = "grz_qc"
+        ext.mqc_section_name = "GRZ QC Results (Deduplicated)"
         publishDir = [
             path:"${params.outdir}/",
             pattern: "*report.{csv,xlsx}",
@@ -91,6 +93,8 @@ process {
     withName: MERGE_REPORTS_UNDEDUPLICATED {
         ext.prefix = "redundant_"
         ext.version_suffix = "redundant"
+        ext.mqc_id = "grz_qc_redundant"
+        ext.mqc_section_name = "GRZ QC Results (Redundant)"
         publishDir = [
             path:"${params.outdir}/",
             pattern: "*report.{csv,xlsx}",

--- a/modules/local/merge_reports/main.nf
+++ b/modules/local/merge_reports/main.nf
@@ -19,9 +19,11 @@ process MERGE_REPORTS {
     def create_alias = task.ext.create_alias ? true : false
     def alias = task.ext.create_alias ?: ''
     def version_suffix = task.ext.version_suffix ? "+${task.ext.version_suffix}" : ""
+    def mqc_id = task.ext.mqc_id ? "--mqc_id ${task.ext.mqc_id}" : ""
+    def mqc_section_name = task.ext.mqc_section_name ? "--mqc_section_name '${task.ext.mqc_section_name}'" : ""
 
     """
-    merge_reports.py ${csv_files} --output_prefix ${prefix}report --workflow_version ${workflow.manifest.version}${version_suffix}
+    merge_reports.py ${csv_files} --output_prefix ${prefix}report --workflow_version ${workflow.manifest.version}${version_suffix} ${mqc_id} ${mqc_section_name}
 
     # If enabled, create a symbolic link named 'report.csv' pointing to the prefixed output
     if [ "${create_alias}" = true ]; then

--- a/modules/local/merge_reports/main.nf
+++ b/modules/local/merge_reports/main.nf
@@ -43,6 +43,7 @@ process MERGE_REPORTS {
     """
     touch ${prefix}report.csv
     touch ${prefix}report.xlsx
+    touch ${prefix}report_mqc.csv
 
     if [ "${create_alias}" = true ]; then
         ln -s ${prefix}report.csv ${alias}


### PR DESCRIPTION
## Summary

The deduplicated and non-deduplicated GRZ QC reports were both emitted as
MultiQC custom content under the same hardcoded section id `grz_qc`. MultiQC
keys custom-content tables by id and by sample, so the two collided: rows for
the same sample overwrote each other and the "GRZ QC Results" table showed
only one set of numbers — whichever report MultiQC loaded last, potentially the
redundant figures, contradicting the deduplicated `report.csv`.

The section id and name are now parametrised per report: the deduplicated
report keeps `grz_qc` ("GRZ QC Results (Deduplicated)"), the redundant report
uses `grz_qc_redundant` ("GRZ QC Results (Redundant)"), and the new id is
registered in the MultiQC `module_order`. Both now render as separate tables.

Verified under the pinned MultiQC 1.32 against the real `merge_reports.py`: two
sections, four samples, deduplicated values preserved.

fix(merge-reports): create report_mqc.csv in stub block

## Tasks

- [x] PR title follows Conventional Commits
- [ ] Request reviews from the relevant people
