### PR TITLE
fix(config): add canonical test profile alias

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -168,6 +168,7 @@ profiles {
         }
     }
 
+    test           { includeConfig 'conf/tests/test_tiny.config'     }
     test_GRCh38    { includeConfig 'conf/tests/test_GRCh38.config'   }
     test_GRCh37    { includeConfig 'conf/tests/test_GRCh37.config'   }
     test_full      { includeConfig 'conf/tests/test_full.config'     }


### PR DESCRIPTION
## Summary

Restores a canonical `test` profile so nf-core ecosystem tooling works again.

`nf-core pipelines download` runs `nextflow inspect -profile <container>,test,test_full` to discover container images. Because the pipeline renamed its minimal test to `test_tiny` and kept no `test` alias, Nextflow aborted with:

```
Unknown configuration profile: 'test'
```

and the download failed.

This points `test` at `conf/tests/test_tiny.config`, so both `test` and `test_full` resolve. `nextflow inspect` (and thus `nf-core download`) succeeds, and the nf-core lint convention of a canonical `test` profile is satisfied.

Fixes #207.
## Tasks

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`, `build:`, `perf:`, `style:`, `revert:`)
  - Use `feat!:` or include `BREAKING CHANGE:` in the body for breaking changes
  - Version bump and `CHANGELOG.md` are handled automatically by release-please on merge to `main`
- [ ] Request reviews from the relevant people
